### PR TITLE
Fix file extensions for delete

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,11 +44,11 @@ const getSizesToDelete = (file, config) => {
     let sizes = [];
     /* Create & Optimize the size based on extension */
     switch(file.ext) {
-      case '.png': sizes.push({suffix:`-${width}-${height}.png`})
+      case '.png': sizes.push({suffix:`-${width}-${height}${file.ext}`})
         break;
-      case '.jpg': sizes.push({suffix:`-${width}-${height}.jpg`})
+      case '.jpg': sizes.push({suffix:`-${width}-${height}${file.ext}`})
         break;
-      case '.jpeg': sizes.push({suffix:`-${width}-${height}.jpg`})
+      case '.jpeg': sizes.push({suffix:`-${width}-${height}${file.ext}`})
         break;
     }
     /* Create the WebP image for each size if enabled */


### PR DESCRIPTION
When a .jpeg file is triggered for delete it was incorrectly pushing .jpg into the delete array